### PR TITLE
ci: bump Cargo.toml version with sed instead of toml-editor action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,11 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Generate Package Version
-        id: version
         shell: pwsh
-        run: Write-Host "::set-output name=version::$('${{ github.event.release.tag_name }}'.substring(1))"
+        run: Add-Content -Path $env:GITHUB_ENV -Value "VERSION=$('${{ github.event.release.tag_name }}'.substring(1))"
 
       - name: Set Package Version
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: Cargo.toml
-          key: package.version
-          value: ${{ steps.version.outputs.version }}
+        run: sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/g" Cargo.toml
 
       - name: Stash Versioned Cargo.toml
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The release build was failing on the version bump step, which relied on the `ciiiii/toml-editor@1.0.0` custom action to write the release version into `Cargo.toml`.

This switches to the same `sed`-based approach used by [`grey`](https://github.com/SierraSoftworks/grey):

- Write the version (derived from the release tag, with the leading `v` stripped) into `$GITHUB_ENV` as `VERSION`.
- Replace the package version line directly with `sed`:
  ```sh
  sed -i "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/g" Cargo.toml
  ```

The regex is anchored to the start of the line (`^version`), so it only touches the `[package]` version and leaves the indented `version = "..."` entries under `[dependencies]` untouched. The versioned `Cargo.toml` continues to be stashed as an artifact for the downstream build jobs, exactly as before.

## Why

The `toml-editor` action was breaking the version bump and, in turn, the release build. Reusing the proven approach from `grey` removes the dependency on a third-party action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFpS447MuKrJBkWSWGB123

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFpS447MuKrJBkWSWGB123)_